### PR TITLE
Menu fix

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
       <div class="trigger">
         {% for my_page in site.pages reversed %}
           {% if my_page.title %}
-          <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a>
+          <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.menu_title }}</a>
           {% endif %}
         {% endfor %}
       </div>

--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About
+menu_title: About
 permalink: /about/
 ---
 [Signhost.com](http://www.signhost.com) is a service that makes it possible to digitally sign, seal or deliver your documents. Documents can be signed directly from your webportal or by sending a signing request by email or other message to the end-user.

--- a/endpoints.html
+++ b/endpoints.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Endpoints
+menu_title: Endpoints
 permalink: /endpoints/
 ---
 

--- a/status-activities.html
+++ b/status-activities.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Statuses & Activities
+menu_title: Statuses & Activities
 permalink: /status-activity/
 ---
   <p>Some of our endpoints return both the status of the transaction and signer activities. A list of all the statuses as well as a list of all the activities can be found below.</p>


### PR DESCRIPTION
Add support for pages with long titles by separating the actual page title and link text for in the menu.
