### PR TITLE
Remove array terminator in request body

### DIFF
--- a/_data/endpoint_examples.yaml
+++ b/_data/endpoint_examples.yaml
@@ -54,7 +54,6 @@ post/api/transaction:
             "ScribbleNameFixed": false,
             "Mobile": "+31612345678",
             "RequireSmsVerification": true
-            ]
           }
           ],
           "SendEmailNotifications": true


### PR DESCRIPTION
There's a stray array terminator in the request body that results in
invalid JSON.