### PR TITLE
Fix typo

### DIFF
--- a/_data/api-swagger.yaml
+++ b/_data/api-swagger.yaml
@@ -491,8 +491,7 @@ definitions:
           "Type": "iDeal",
           "Iban": "NL01ABNA0123456789",
           "AccountHolderName": "DOE J",
-          "AccountHolderCity": ""
-        }
+          "AccountHolderCity": "Amsterdam"
       }
       ```
 


### PR DESCRIPTION
iDEAL example fix typo } and adds city name Amsterdam to example.