### PR TITLE
SIG-2124 DocumentSealDefaultFix

### DIFF
--- a/_data/api-swagger.yaml
+++ b/_data/api-swagger.yaml
@@ -222,7 +222,7 @@ definitions:
           $ref: '#/definitions/FileEntry'
       Seal:
         type: boolean
-        default: true
+        default: false
         description: Seal the document before sending to the signers.
       Signers:
         type: array


### PR DESCRIPTION
The default value of Seal was on true, which should be false.