### PR TITLE
SIG-2245 Document the custom subjects for sign requests and receiver mails

### DIFF
--- a/_data/api-swagger.yaml
+++ b/_data/api-swagger.yaml
@@ -270,6 +270,12 @@ definitions:
                 Available / valid if `SendSignRequest` is set to false.
               type: string
               readOnly: true
+            SignRequestSubject:
+              type: string
+              description: |
+                The subject of the sign request email in plain text.
+                Maximum of 64 characters allowed.
+                Omitting this parameter will enable the default subject.
             SignRequestMessage:
               description: |
                 The message of the sign request in plain text.
@@ -380,6 +386,12 @@ definitions:
               type: string
               description: The language of the receiver, only de-DE, en-US, es-ES, fr-FR, it-IT and nl-NL are allowed.
               default: nl-NL
+            Subject:
+              type: string
+              description: |
+                The subject of the receiver email in plain text.
+                Maximum of 64 characters allowed.
+                mitting this parameter will enable the default subject.
             Message:
               type: string
               description: The email message towards the receiver in plain text. Newlines can be created by including a \n in the json, HTML is not allowed.

--- a/_data/api-swagger.yaml
+++ b/_data/api-swagger.yaml
@@ -391,7 +391,7 @@ definitions:
               description: |
                 The subject of the receiver email in plain text.
                 Maximum of 64 characters allowed.
-                mitting this parameter will enable the default subject.
+                Omitting this parameter will enable the default subject.
             Message:
               type: string
               description: The email message towards the receiver in plain text. Newlines can be created by including a \n in the json, HTML is not allowed.


### PR DESCRIPTION
Documents the parameters `SignRequestSubject` and `Subject` for signers and receivers respectively.