### PR TITLE
Fix sample Accept headers

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ Below you find a HTTP request header example:
     Content-Type: application/json
     Authorization: APIKey {usertoken here}
     Application: APPKey {appkey here}
-    Accept: */*
+    Accept: application/vnd.signhost.v1+json
     Connection: keep-alive
 
 ## Get signed document and receipt


### PR DESCRIPTION
Sending in Accept: \*/\* is not advised, so instead we show an example of our versioned headers