### PR TITLE
Cut SH-DisplayName header from PUT cURL example

### DIFF
--- a/_data/endpoint_examples.yaml
+++ b/_data/endpoint_examples.yaml
@@ -69,7 +69,6 @@ put/api/transaction/{transactionId}/file/{fileId}:
       curl \
         -H "Authorization: APIKey {usertoken here}" \
         -H "Application: APPKey {appkey here}" \
-        -H "SH-DisplayName: Your personal contract" \
         -H "Content-Type: application/pdf" \
         -H "Digest: SHA-256=HtHRpLOZBEMnTpQS6Zn12veC4uhjtMwamfVAwmPQPmE=" \
       -XPUT \


### PR DESCRIPTION
The SH-DisplayName header isn't documented anywhere else and the usage of the header can cause some issues in certain scenarios.