### PR TITLE
Add link to the Python client library

### DIFF
--- a/index.md
+++ b/index.md
@@ -150,6 +150,7 @@ There are a few libraries and demos available to make connecting to our API easi
 *   [PHP Demo Client](https://github.com/Evidos/signhost-phpdemoclient)
 *   [Java Client Library](https://github.com/Evidos/OndertekenenDemo-Java)
 *   [SignHost Ruby Gem](https://rubygems.org/gems/sign_host)
+*   [Python Client Library](https://github.com/foarsitter/signhost-api-python-client)
 
 ## Handy tools
 

--- a/index.md
+++ b/index.md
@@ -150,7 +150,7 @@ There are a few libraries and demos available to make connecting to our API easi
 *   [PHP Demo Client](https://github.com/Evidos/signhost-phpdemoclient)
 *   [Java Client Library](https://github.com/Evidos/OndertekenenDemo-Java)
 *   [SignHost Ruby Gem](https://rubygems.org/gems/sign_host)
-*   [Python Client Library](https://github.com/foarsitter/signhost-api-python-client)
+*   [Python Client Library (external)](https://github.com/foarsitter/signhost-api-python-client)
 
 ## Handy tools
 


### PR DESCRIPTION
Since some time there is a client library for Python. This PR adds a link to the docs to the library. 