### PR TITLE
Reorder sentence for clarity in sealing.md

### DIFF
--- a/docs/guide/features/sealing.md
+++ b/docs/guide/features/sealing.md
@@ -48,7 +48,7 @@ POST /api/transaction
 }
 ```
 
-In this example, the signer will first sign the document, and then Signhost will apply a seal on behalf of your organization.
+In this example, Signhost will apply a seal on behalf of your organization, then the signer will sign the document.
 
 ### Creating a seal-only transaction
 


### PR DESCRIPTION
Changed order around so signing and sealing match reality. Sealing comes first.