### PR TITLE
SIG-6013: Add SDK downloads page with click-through license agreement

### DIFF
--- a/components/ClickThroughGate.tsx
+++ b/components/ClickThroughGate.tsx
@@ -55,9 +55,7 @@ export const ClickThroughGate = ({ children }: { children: ReactNode }) => {
     return (
       <div>
         <div style={styles.acceptedBanner}>
-          <span>
-            You accepted the SDK License Agreement on {date}.
-          </span>
+          <span>You accepted the SDK License Agreement on {date}.</span>
         </div>
         {children}
       </div>

--- a/components/ClickThroughGate.tsx
+++ b/components/ClickThroughGate.tsx
@@ -1,0 +1,150 @@
+import { type ReactNode, useEffect, useState } from "react";
+import { LicenseText } from "./LicenseText";
+
+const STORAGE_KEY = "signhost-sdk-license-accepted";
+
+interface Acceptance {
+  accepted: boolean;
+  timestamp: string;
+}
+
+function getAcceptance(): Acceptance | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed?.accepted === true && typeof parsed.timestamp === "string") {
+      return parsed as Acceptance;
+    }
+  } catch {
+    // Corrupted or unavailable localStorage
+  }
+  return null;
+}
+
+export const ClickThroughGate = ({ children }: { children: ReactNode }) => {
+  const [mounted, setMounted] = useState(false);
+  const [acceptance, setAcceptance] = useState<Acceptance | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    setAcceptance(getAcceptance());
+    setMounted(true);
+  }, []);
+
+  const handleAccept = () => {
+    const record: Acceptance = {
+      accepted: true,
+      timestamp: new Date().toISOString(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+    setAcceptance(record);
+    setChecked(false);
+  };
+
+  // Avoid hydration mismatch — render nothing until client-side mount
+  if (!mounted) return null;
+
+  if (acceptance) {
+    const date = new Date(acceptance.timestamp).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    return (
+      <div>
+        <div style={styles.acceptedBanner}>
+          <span>
+            You accepted the SDK License Agreement on {date}.
+          </span>
+        </div>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={styles.licenseContainer}>
+        <LicenseText />
+      </div>
+      <label style={styles.checkboxLabel}>
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => setChecked(e.target.checked)}
+          style={styles.checkbox}
+        />
+        I have read and agree to the SDK License Agreement
+      </label>
+      <div>
+        <button
+          type="button"
+          disabled={!checked}
+          onClick={handleAccept}
+          style={{
+            ...styles.acceptButton,
+            ...(checked ? {} : styles.acceptButtonDisabled),
+          }}
+        >
+          Accept and continue
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  licenseContainer: {
+    maxHeight: "400px",
+    overflowY: "auto",
+    border: "1px solid var(--rp-c-divider)",
+    borderRadius: "8px",
+    padding: "24px",
+    marginBottom: "20px",
+    backgroundColor: "var(--rp-c-bg-soft)",
+    fontSize: "14px",
+    lineHeight: "1.6",
+  },
+  checkboxLabel: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    marginBottom: "16px",
+    fontSize: "15px",
+    fontWeight: 500,
+    cursor: "pointer",
+    userSelect: "none",
+  },
+  checkbox: {
+    width: "18px",
+    height: "18px",
+    accentColor: "var(--rp-c-brand)",
+    cursor: "pointer",
+  },
+  acceptButton: {
+    padding: "10px 28px",
+    fontSize: "15px",
+    fontWeight: 600,
+    color: "#fff",
+    backgroundColor: "var(--rp-c-brand)",
+    border: "none",
+    borderRadius: "6px",
+    cursor: "pointer",
+    transition: "opacity 0.2s",
+  },
+  acceptButtonDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
+  },
+  acceptedBanner: {
+    padding: "12px 16px",
+    marginBottom: "24px",
+    borderRadius: "8px",
+    backgroundColor: "var(--rp-c-bg-soft)",
+    border: "1px solid var(--rp-c-divider-light)",
+    fontSize: "14px",
+    color: "var(--rp-c-text-2)",
+  },
+};

--- a/components/LicenseText.tsx
+++ b/components/LicenseText.tsx
@@ -1,0 +1,91 @@
+export const LicenseText = () => (
+  <>
+    <h3>Entrust Signhost SDK License Agreement</h3>
+    <p>
+      <em>Last updated: August 2026</em>
+    </p>
+    <p>
+      PLEASE READ THIS SDK LICENSE AGREEMENT ("AGREEMENT") CAREFULLY BEFORE
+      DOWNLOADING OR USING THE ENTRUST SIGNHOST SDK. BY CLICKING "I ACCEPT" OR
+      BY DOWNLOADING, INSTALLING, OR USING THE SDK, YOU AGREE TO BE BOUND BY THE
+      TERMS OF THIS AGREEMENT.
+    </p>
+
+    <h4>1. Grant of license</h4>
+    <p>
+      Subject to the terms of this Agreement, Entrust Corporation ("Entrust")
+      grants you a limited, non-exclusive, non-transferable, revocable license
+      to use the Signhost Software Development Kit ("SDK") solely for the
+      purpose of developing, testing, and deploying applications that integrate
+      with the Entrust Signhost API.
+    </p>
+
+    <h4>2. Restrictions</h4>
+    <p>You may not:</p>
+    <ul>
+      <li>
+        Sublicense, sell, lease, or otherwise distribute the SDK to any third
+        party.
+      </li>
+      <li>
+        Modify, decompile, reverse engineer, or disassemble the SDK or any part
+        thereof, except to the extent permitted by applicable law.
+      </li>
+      <li>Use the SDK to develop competing products or services.</li>
+      <li>
+        Remove or alter any proprietary notices, labels, or marks on the SDK.
+      </li>
+    </ul>
+
+    <h4>3. Intellectual property</h4>
+    <p>
+      The SDK and all copies thereof are proprietary to Entrust and title
+      thereto remains in Entrust. All applicable rights to patents, copyrights,
+      trademarks, and trade secrets in the SDK are and shall remain in Entrust.
+    </p>
+
+    <h4>4. No warranty</h4>
+    <p>
+      THE SDK IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. ENTRUST DOES NOT
+      WARRANT THAT THE SDK WILL BE ERROR-FREE OR UNINTERRUPTED.
+    </p>
+
+    <h4>5. Limitation of liability</h4>
+    <p>
+      IN NO EVENT SHALL ENTRUST BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL,
+      CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUE,
+      WHETHER INCURRED DIRECTLY OR INDIRECTLY, ARISING OUT OF YOUR USE OF OR
+      INABILITY TO USE THE SDK.
+    </p>
+
+    <h4>6. Termination</h4>
+    <p>
+      This Agreement is effective until terminated. Entrust may terminate this
+      Agreement at any time if you fail to comply with any term herein. Upon
+      termination, you must cease all use of the SDK and destroy all copies in
+      your possession.
+    </p>
+
+    <h4>7. Export compliance</h4>
+    <p>
+      You agree to comply with all applicable export and re-export control laws
+      and regulations in connection with your use of the SDK.
+    </p>
+
+    <h4>8. Governing law</h4>
+    <p>
+      This Agreement shall be governed by and construed in accordance with the
+      laws of the Province of Ontario, Canada, without regard to its conflict of
+      laws principles.
+    </p>
+
+    <h4>9. Entire agreement</h4>
+    <p>
+      This Agreement constitutes the entire agreement between you and Entrust
+      regarding the SDK and supersedes all prior agreements and understandings,
+      whether written or oral, relating to the SDK.
+    </p>
+  </>
+);

--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -18,6 +18,10 @@
     ]
   },
   {
+    "text": "SDKs",
+    "link": "/sdk"
+  },
+  {
     "text": "About",
     "link": "/about"
   },

--- a/docs/sdk.mdx
+++ b/docs/sdk.mdx
@@ -1,0 +1,32 @@
+---
+title: SDKs
+sidebar: false
+outline: false
+---
+
+import { ClickThroughGate } from "../components/ClickThroughGate";
+
+# SDKs
+
+Download the Signhost SDK for your platform to get started with the API integration. You must accept the license agreement below before accessing the downloads.
+
+<ClickThroughGate>
+
+## Downloads
+
+| SDK | Download |
+| --- | --- |
+| Signhost Signer SDK | [Download](https://github.com/Evidos/signhost-signer-sdk/releases) |
+
+:::tip
+Can't find the SDK for your platform? Check out the [API reference](/openapi) and [quick start guide](/guide/start/quick-start) to integrate directly with the REST API.
+:::
+
+## Getting started
+
+1. Download the SDK for your platform
+2. Follow the installation instructions in the SDK's README
+3. Configure your API credentials (see [authentication](/guide/features/authentication))
+4. Create your first transaction using the [quick start guide](/guide/start/quick-start)
+
+</ClickThroughGate>


### PR DESCRIPTION
## Summary

Adds a new **SDKs** page (/sdk) to the developer documentation that gates download links behind a client-side click-through license agreement. Users must accept the agreement before seeing download links.

## How it works

- **ClickThroughGate** React component checks localStorage for prior acceptance
- First visit: shows the license text in a scrollable container, a checkbox, and an _Accept and continue_ button (disabled until checkbox is checked)
- After acceptance: shows the download links with a banner noting the acceptance date
- Acceptance is stored as { accepted: true, timestamp: ISO } in localStorage
- No server-side enforcement — this is the industry-standard approach for static-site SDK distribution (same pattern as Android SDK, Oracle JDK)

## Placeholders (to be replaced before merge)

- [ ] **License text** in /components/LicenseText.tsx/ — currently placeholder legal text; needs final version from legal team
- [ ] **Download URL** in /docs/sdk.mdx/ — currently points to /https://github.com/Evidos/signhost-signer-sdk/releases/ as placeholder

## Files changed

| File | Change |
|------|--------|
| /components/ClickThroughGate.tsx/ | New — click-through gate component |
| /components/LicenseText.tsx/ | New — placeholder license agreement text |
| /docs/sdk.mdx/ | New — SDK downloads page |
| /docs/_nav.json/ | Modified — added SDKs nav entry |

## Testing

1. Open devdocs > navigate to /sdk
2. Verify license text is shown, downloads are hidden
3. Check the checkbox and click Accept → downloads appear
4. Refresh → acceptance persists, banner shows date
5. DevTools console: /localStorage.removeItem('signhost-sdk-license-accepted') + refresh to reset (or open incognito)